### PR TITLE
Fixed conflict with brewed python

### DIFF
--- a/uranium/scripts/uranium_standalone
+++ b/uranium/scripts/uranium_standalone
@@ -7,7 +7,7 @@
 VENV_URL = "https://pypi.python.org/packages/source/v/virtualenv/virtualenv-{major}.{minor}.{rev}.tar.gz"
 VENV_MAJOR = 13
 VENV_MINOR = 1
-VENV_REV = 0
+VENV_REV = 2
 
 import io
 import logging

--- a/uranium/scripts/uranium_standalone
+++ b/uranium/scripts/uranium_standalone
@@ -156,6 +156,9 @@ def _install_virtualenv(install_dir):
 
     LOGGER.info("installing virtualenv...")
 
+    if sys.prefix:
+        _override_pydistutils_prefix(install_dir)
+        
     temp_dir = tempfile.mkdtemp()
     try:
         _download_virtualenv(temp_dir)
@@ -182,6 +185,26 @@ def _get_site_file_path(venv_directory):
     # we strip the last character 'c' in case it's a .pyc file
     # want the .py
     ).communicate()[0].decode('utf-8').rstrip('c\n')
+
+
+def _override_pydistutils_prefix(install_dir):
+    """
+    write a .pydistutils.cfg file to override the prefix variable
+    """
+    if os.name == 'posix':
+        env_distutils_filename = '.pydistutils.cfg'
+    else:
+        env_distutils_filename = 'pydistutils.cfg'
+
+    if not os.path.exists(install_dir):
+        os.makedirs(install_dir)
+    env_distutils_file = os.path.join(install_dir, env_distutils_filename)
+
+    with open(env_distutils_file, 'w') as fh:
+        fh.write("""
+[install]
+prefix={prefix_path}
+        """.format(prefix_path=install_dir).strip())
 
 
 def _inject_to_site_py(site_py_file):

--- a/uranium/scripts/uranium_standalone
+++ b/uranium/scripts/uranium_standalone
@@ -110,6 +110,9 @@ def main(argv):
     current_dir = os.getcwd()
     uranium_dir = options.uranium_dir
 
+    if sys.prefix:
+        _write_pydistutils_cfg(current_dir)
+
     # first we try to see if Uranium is already installed
     # on the system.
     uranium = retrieve_system_uranium()
@@ -132,6 +135,7 @@ def main(argv):
     LOGGER.info("setting up uranium...")
     _install_uranium(install_dir, uranium_dir=uranium_dir,
                      version=options.version)
+
     LOGGER.info("done!")
 
     LOGGER.debug("running uranium...")
@@ -157,8 +161,8 @@ def _install_virtualenv(install_dir):
     LOGGER.info("installing virtualenv...")
 
     if sys.prefix:
-        _override_pydistutils_prefix(install_dir)
-        
+        _write_pydistutils_cfg(install_dir)
+
     temp_dir = tempfile.mkdtemp()
     try:
         _download_virtualenv(temp_dir)
@@ -187,7 +191,7 @@ def _get_site_file_path(venv_directory):
     ).communicate()[0].decode('utf-8').rstrip('c\n')
 
 
-def _override_pydistutils_prefix(install_dir):
+def _write_pydistutils_cfg(install_dir):
     """
     write a .pydistutils.cfg file to override the prefix variable
     """


### PR DESCRIPTION
Brewed python sets a `prefix` option of `$HOME/bin` in *~/.pydistutils.cfg*. Virtualenv does not provide an option to ignore this value, essentially causing it to ignore the --no-site-packages flag. This causes scripts/uranium_standalone to fail, because it expects pip and others in `[env dir]/bin`.

This fixes Sprinter for me: https://github.com/toumorokoshi/sprinter/issues/63

I've tested this by hacking the change into a local copy of the uranium_standalone script, but have not tested it from this repo.