### PR TITLE
Validate version specifier for package installs

### DIFF
--- a/tests/packages/test_install_command.py
+++ b/tests/packages/test_install_command.py
@@ -1,3 +1,5 @@
+import pytest
+from uranium.exceptions import PackageException
 from uranium.packages.install_command import _create_args
 
 
@@ -26,3 +28,14 @@ def test_create_args_includes_install_options():
         "--install-option", "--install-lib=/opt/srv/lib",
         "pytest"
     ]
+
+
+def test_create_args_raises_on_invalid_version():
+    with pytest.raises(PackageException) as exc:
+        _create_args("pytest", version="3.1.3")
+    assert "Invalid version specifier" in str(exc)
+
+
+def test_create_args_accepts_valid_version():
+    args = _create_args("pytest", version=">=3.1.3")
+    assert args == ["pytest>=3.1.3"]

--- a/uranium/packages/__init__.py
+++ b/uranium/packages/__init__.py
@@ -61,6 +61,9 @@ class Packages(object):
         install is used when installing a python package into the environment.
 
         if version is set, the specified version of the package will be installed.
+        The specified version should be a full `PEP 440`_ version specifier (i.e. "==1.2.0")
+
+        .. _`PEP 440`: https://www.python.org/dev/peps/pep-0440/
 
         if develop is set to True, the package will be installed as editable: the source
         in the directory passed will be used when using that package.

--- a/uranium/packages/install_command.py
+++ b/uranium/packages/install_command.py
@@ -1,5 +1,7 @@
+import pkg_resources
 from pip.commands import InstallCommand, UninstallCommand
 from pip.req.req_file import process_line
+from ..exceptions import PackageException
 from ..lib.compat import urlparse
 
 
@@ -100,6 +102,12 @@ def _create_args(package_name, upgrade=False, develop=False,
 
     requirement = package_name
     if version:
-        requirement += version
+        versioned_requirement = requirement + version
+        if not pkg_resources.Requirement.parse(versioned_requirement).specs:
+            raise PackageException(
+                "Cannot parse requirement for package %s. " % requirement +
+                "Invalid version specifier: %s." % version
+            )
+        requirement = versioned_requirement
     args.append(requirement)
     return args


### PR DESCRIPTION
Addresses #30.

Using `pkg_resources` to validate version specifiers. Raises an exception when unable to parse a version specifier.

(Also added a clarification in the docs that the version specifier should be a full specifier, and not just a version number)