### PR TITLE
Add support for per-package install_options configuration

### DIFF
--- a/uranium/packages/__init__.py
+++ b/uranium/packages/__init__.py
@@ -21,6 +21,7 @@ class Packages(object):
         self._virtualenv_dir = virtualenv_dir
         self._versions = Versions()
         self._index_urls = list(DEFAULT_INDEX_URLS)
+        self.config = {}
 
     @property
     def versions(self):
@@ -86,6 +87,7 @@ class Packages(object):
         req_set = install(
             name, upgrade=upgrade, develop=develop, version=version,
             index_urls=self.index_urls, constraint_dict=self.versions,
+            packages_config=self.config,
             install_options=install_options
         )
         if req_set:

--- a/uranium/packages/install_command.py
+++ b/uranium/packages/install_command.py
@@ -12,10 +12,6 @@ class UraniumInstallCommand(InstallCommand):
 
     * constraints
     """
-    def parse_and_run(self, args):
-        options, args = self.parse_args(args)
-        self.run(options, args)
-
     def populate_requirement_set(self, requirement_set, args, options,
                                  finder, session, name, wheel_cache):
         # add all of the standard reqs first.


### PR DESCRIPTION
This allows individual packages to be configured with custom
install_options. This works for both packages installed directly and
packages installed as dependencies of other packages.

For example:

    build.packages.config['foo'] = {
        'install_options': ['--no-compile']
    }

If the package "foo" were scheduled for installation (either directly or
as a dependency of another package), this configuration would cause the
package "foo" to be installed with the --no-compile installation option.

----

This also removes the obsolete parse_and_run method from UraniumInstallCommand.