### PR TITLE
Improve package post-install version calculation performance

### DIFF
--- a/uranium/packages/__init__.py
+++ b/uranium/packages/__init__.py
@@ -92,8 +92,19 @@ class Packages(object):
         )
         if req_set:
             for req in req_set.requirements.values():
-                if req.installed_version:
-                    self.versions[req.name] = ("==" + req.installed_version)
+                # Don't examine packages that weren't modified
+                if not req.install_succeeded:
+                    continue
+                # Retrieving a package's installed version is time consuming.
+                # Prefer the calculated package specifier if available, and use
+                # the installed version if not.
+                new_constraint = str(req.specifier) if req.specifier else None
+                if not new_constraint:
+                    installed_version = req.installed_version
+                    if installed_version:
+                        new_constraint = '=={}'.format(installed_version)
+                if new_constraint:
+                    self.versions[req.name] = new_constraint
         # if virtualenv dir is set, we should make the environment relocatable.
         # this will fix issues with commands not being usable by the
         # uranium via build.executables.run


### PR DESCRIPTION
After installing packages, uranium stores the installed version of each
package to provide as constraints to successive package installation
commands.

The method pip uses to retrieve the version of an installed package is
inefficient, which often results in noticeable delay (on the order of
seconds for each invocation of build.packages.install).

This change reduces the frequency of retrieving each package's installed
version during the package post-installation phase with the following:

- Packages that were not installed as a result of the preceding install
  command are skipped (as the installed version of any prior installed
  packages should already be stored in the versions cache)

- If a constraint specifier was computed during package dependency
  resolution, use that constraint specifier instead of
  retrieving the installed version

Typically, the vast majority of installed packages are dependencies with
constraints attached, requiring installed version retrieval for only a
small proportion of packages. This results in a significant performance
gain.

This implements the performance improvement called for by #40.