### PR TITLE
_is_package_already_installed should also evaluate the version in build.packages.versions

### DIFF
--- a/tests/test_packages_full.py
+++ b/tests/test_packages_full.py
@@ -54,6 +54,29 @@ def test_install(tmpdir):
     assert code == 0
 
 
+def test_install_with_version_dict_updated(tmpdir):
+    UBUILD = """
+def main(build):
+
+    build.packages.install("requests", version="==2.15.1")
+    build.packages.versions["requests"] = "==2.18.0"
+    build.packages.install("requests")
+    print(build.packages.versions["requests"])
+
+    import pkg_resources
+    pkg_resources.get_distribution("requests==2.18.0")
+""".strip()
+
+    tmpdir.join("ubuild.py").write(UBUILD)
+    code, out, err = execute_script(
+        "uranium_standalone", "--uranium-dir", URANIUM_SOURCE_ROOT,
+        cwd=tmpdir.strpath
+    )
+
+    assert code == 0
+    assert "2.18.0" in out.decode("utf-8")
+
+
 def test_uninstall(tmpdir):
     # we need to create a virtualenv
     tmpdir.join("ubuild.py").write(URANIUM_PY_UNINSTALL)

--- a/uranium/packages/__init__.py
+++ b/uranium/packages/__init__.py
@@ -76,8 +76,6 @@ class Packages(object):
         if install_options is provided, it should be a list of options, like
         ["--prefix=/opt/srv", "--install-lib=/opt/srv/lib"]
         """
-        if self._is_package_already_installed(name, version):
-            return
         p_assert(
             not (develop and version),
             "unable to set both version and develop flags when installing packages"
@@ -86,6 +84,8 @@ class Packages(object):
             if version is None:
                 version = self.versions[name]
             del self.versions[name]
+        if self._is_package_already_installed(name, version):
+            return
         req_set = install(
             name, upgrade=upgrade, develop=develop, version=version,
             index_urls=self.index_urls, constraint_dict=self.versions,


### PR DESCRIPTION
Issue:
1. package A (version=0.1.1) has been installed
2. `build.packages.versions` has been updated to `{"A": ">=0.2.1"}`
3. `build.packages.install("A")` will not upgrade A, because `_is_package_already_installed` will be `True` if we don't explicitly pass `version>=0.2.1` with the install function call, like `build.packages.install("A", version=">=0.2.1")`

https://github.com/toumorokoshi/uranium/blob/master/uranium/packages/__init__.py#L79